### PR TITLE
Add tracing-based logging and CLI for hestia-engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bfae7c152994a31dc7d99b8eeac7784a919f71d1b306f4b83217e110fd3824c"
 dependencies = [
  "accesskit",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ checksum = "692dd318ff8a7a0ffda67271c4bd10cf32249656f4e49390db0b26ca92b095f2"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
+ "hashbrown 0.15.5",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -88,7 +88,7 @@ checksum = "70a042b62c9c05bf7b616f015515c17d2813f3ba89978d6f4fc369735d60700a"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
+ "hashbrown 0.15.5",
  "static_assertions",
  "windows 0.61.3",
  "windows-core 0.61.2",
@@ -176,6 +176,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -601,6 +651,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +718,12 @@ dependencies = [
  "termcolor",
  "unicode-width 0.2.0",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -815,6 +920,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1140,6 +1259,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventheader"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89dc8df7ddacdd9cf742953c59028a0f449c63fd9cf32f1e198914d5e50d7a2f"
+dependencies = [
+ "eventheader_macros",
+ "eventheader_types",
+ "tracepoint",
+]
+
+[[package]]
+name = "eventheader_dynamic"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1222f93b6339a12943120151396ebe8a1cf10e6c7e0aae7580a9ee12c67847"
+dependencies = [
+ "eventheader",
+]
+
+[[package]]
+name = "eventheader_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de94052aeafe86e301f44de9a6ad7543a5727da1893f87e42f0dc87fb3d684e3"
+
+[[package]]
+name = "eventheader_types"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a304dcb23737a8da95d4e9fd323d9ce201774ec280f2ae73ef95b271dff59aef"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,7 +1595,7 @@ checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags 2.9.4",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1466,6 +1617,12 @@ dependencies = [
  "crunchy",
  "num-traits",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1495,8 +1652,10 @@ name = "hestia-engine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger",
- "log",
+ "clap",
+ "tracing",
+ "tracing-etw",
+ "tracing-subscriber",
  "windows-service",
 ]
 
@@ -1670,7 +1829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1702,6 +1861,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1776,6 +1941,12 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1856,7 +2027,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1951,7 +2122,7 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown",
+ "hashbrown 0.15.5",
  "hexf-parse",
  "indexmap",
  "log",
@@ -2021,6 +2192,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "num-traits"
@@ -2339,6 +2519,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "orbclient"
@@ -2790,6 +2976,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,6 +3232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,6 +3307,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracelogging"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0015caf14cad7613b7bbbb9ee44399ad9a694307be545d8af4e2711178e547e"
+dependencies = [
+ "tracelogging_macros",
+]
+
+[[package]]
+name = "tracelogging_dynamic"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81357ee826ff21547ab41ceea8a4fcf58d60681de2055e65bc704c32e6e3614b"
+dependencies = [
+ "tracelogging",
+]
+
+[[package]]
+name = "tracelogging_macros"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e2d891464ff33bc1814c4cbbb251bae7800458b1efdb6ac8b7c01ee6382563"
+
+[[package]]
+name = "tracepoint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92536f9f33905adc8203fda89e8055cb02daf4cebc470fbd0d9593856ba0f1d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,6 +3368,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-etw"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199284f147f25782ce971eb1dbefabc8411cc2a6d960762220b54500802e69f"
+dependencies = [
+ "chrono",
+ "dashmap",
+ "eventheader",
+ "eventheader_dynamic",
+ "once_cell",
+ "paste",
+ "thiserror 1.0.69",
+ "tracelogging",
+ "tracelogging_dynamic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3211,6 +3494,18 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -3485,7 +3780,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cfg_aliases",
  "document-features",
- "hashbrown",
+ "hashbrown 0.15.5",
  "js-sys",
  "log",
  "naga",
@@ -3515,7 +3810,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cfg_aliases",
  "document-features",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "log",
  "naga",
@@ -3582,7 +3877,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown",
+ "hashbrown 0.15.5",
  "js-sys",
  "khronos-egl",
  "libc",

--- a/hestia-engine/Cargo.toml
+++ b/hestia-engine/Cargo.toml
@@ -9,8 +9,10 @@ description = "Detection engine for Hestia EDR - analyzes events and detects thr
 
 [dependencies]
 anyhow.workspace = true
-log.workspace = true
-env_logger.workspace = true
+clap = { version = "4.5", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-etw = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.6"

--- a/hestia-engine/src/main.rs
+++ b/hestia-engine/src/main.rs
@@ -6,11 +6,13 @@
 
 #[cfg(windows)]
 mod win_service {
-    use anyhow::Result;
-    use log::{error, info, warn};
+    use anyhow::{anyhow, Result};
+    use clap::Parser;
     use std::ffi::OsString;
     use std::sync::mpsc::{self, RecvTimeoutError};
     use std::time::Duration;
+    use tracing::{error, info, warn};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
     use windows_service::define_windows_service;
     use windows_service::service::{
         ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
@@ -19,80 +21,134 @@ mod win_service {
     use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
     use windows_service::service_dispatcher;
 
+    use tracing_etw::EtwLayer;
+
+    #[derive(Parser, Debug, Clone, Copy)]
+    #[command(
+        name = "hestia-engine",
+        about = "Hestia detection engine Windows service",
+        author,
+        version
+    )]
+    pub struct Cli {
+        /// Run the engine in the foreground with console logging instead of ETW
+        #[arg(long)]
+        pub foreground: bool,
+    }
+
     const SERVICE_NAME: &str = "EDR_Service";
     const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
 
     define_windows_service!(ffi_service_main, service_main);
 
-    pub fn main() {
-        // Initialize a basic logger (useful if running under console during dev)
-        let _ = env_logger::try_init();
-
-        // Start the service control dispatcher. This call blocks until service exits.
-        if let Err(e) = service_dispatcher::start(SERVICE_NAME, ffi_service_main) {
-            // If not running as a real service, just log and return an error.
-            // This keeps behavior explicit and avoids surprises.
-            error!("Failed to start service dispatcher: {e}");
+    pub fn main(args: Cli) -> Result<()> {
+        if args.foreground {
+            run_engine(RuntimeMode::Foreground, Vec::new())
+        } else {
+            service_dispatcher::start(SERVICE_NAME, ffi_service_main)
+                .map_err(|err| anyhow!("Failed to start service dispatcher: {err}"))
         }
     }
 
     fn service_main(args: Vec<OsString>) {
-        if let Err(e) = run_service(args) {
+        if let Err(e) = run_engine(RuntimeMode::Service, args) {
             error!("Service error: {e:?}");
         }
     }
 
-    fn run_service(_args: Vec<OsString>) -> Result<()> {
-        // Channel used to signal stop/shutdown from the control handler
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum RuntimeMode {
+        Service,
+        Foreground,
+    }
+
+    type StatusHandle = Option<service_control_handler::ServiceStatusHandle>;
+
+    fn init_tracing(mode: RuntimeMode) -> Result<Option<tracing_etw::EtwLayerGuard>> {
+        match mode {
+            RuntimeMode::Foreground => {
+                tracing_subscriber::registry()
+                    .with(tracing_subscriber::fmt::layer().with_target(true))
+                    .try_init()?;
+                Ok(None)
+            }
+            RuntimeMode::Service => {
+                let (layer, guard) = EtwLayer::new("HestiaEngine")?;
+                tracing_subscriber::registry().with(layer).try_init()?;
+                Ok(Some(guard))
+            }
+        }
+    }
+
+    fn set_status(handle: &StatusHandle, status: ServiceStatus) -> windows_service::Result<()> {
+        if let Some(handle) = handle {
+            handle.set_service_status(status)?;
+        }
+        Ok(())
+    }
+
+    fn run_engine(mode: RuntimeMode, _args: Vec<OsString>) -> Result<()> {
         let (tx, rx) = mpsc::channel::<ServiceControl>();
 
-        let handler = move |control_event: ServiceControl| -> ServiceControlHandlerResult {
-            match control_event {
-                ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
-                ServiceControl::Stop
-                | ServiceControl::Shutdown
-                | ServiceControl::Pause
-                | ServiceControl::Continue => {
-                    let _ = tx.send(control_event);
-                    ServiceControlHandlerResult::NoError
+        let status_handle = if mode == RuntimeMode::Service {
+            let handler = move |control_event: ServiceControl| -> ServiceControlHandlerResult {
+                match control_event {
+                    ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+                    ServiceControl::Stop
+                    | ServiceControl::Shutdown
+                    | ServiceControl::Pause
+                    | ServiceControl::Continue => {
+                        let _ = tx.send(control_event);
+                        ServiceControlHandlerResult::NoError
+                    }
+                    other => {
+                        warn!("Unhandled control: {other:?}");
+                        ServiceControlHandlerResult::NotImplemented
+                    }
                 }
-                other => {
-                    warn!("Unhandled control: {other:?}");
-                    ServiceControlHandlerResult::NotImplemented
-                }
-            }
+            };
+
+            Some(service_control_handler::register(SERVICE_NAME, handler)?)
+        } else {
+            None
         };
 
-        let status_handle = service_control_handler::register(SERVICE_NAME, handler)?;
+        let _guard = init_tracing(mode)?;
 
         // Report start pending while initializing
-        status_handle.set_service_status(ServiceStatus {
-            service_type: SERVICE_TYPE,
-            current_state: ServiceState::StartPending,
-            controls_accepted: ServiceControlAccept::STOP
-                | ServiceControlAccept::SHUTDOWN
-                | ServiceControlAccept::PAUSE_CONTINUE,
-            exit_code: ServiceExitCode::Win32(0),
-            checkpoint: 1,
-            wait_hint: Duration::from_secs(10),
-            process_id: None,
-        })?;
+        set_status(
+            &status_handle,
+            ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: ServiceState::StartPending,
+                controls_accepted: ServiceControlAccept::STOP
+                    | ServiceControlAccept::SHUTDOWN
+                    | ServiceControlAccept::PAUSE_CONTINUE,
+                exit_code: ServiceExitCode::Win32(0),
+                checkpoint: 1,
+                wait_hint: Duration::from_secs(10),
+                process_id: None,
+            },
+        )?;
 
         // TODO: Initialize engine subsystems here
         info!("Hestia Engine initializing...");
 
         // Transition to Running
-        status_handle.set_service_status(ServiceStatus {
-            service_type: SERVICE_TYPE,
-            current_state: ServiceState::Running,
-            controls_accepted: ServiceControlAccept::STOP
-                | ServiceControlAccept::SHUTDOWN
-                | ServiceControlAccept::PAUSE_CONTINUE,
-            exit_code: ServiceExitCode::Win32(0),
-            checkpoint: 0,
-            wait_hint: Duration::from_secs(0),
-            process_id: None,
-        })?;
+        set_status(
+            &status_handle,
+            ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: ServiceState::Running,
+                controls_accepted: ServiceControlAccept::STOP
+                    | ServiceControlAccept::SHUTDOWN
+                    | ServiceControlAccept::PAUSE_CONTINUE,
+                exit_code: ServiceExitCode::Win32(0),
+                checkpoint: 0,
+                wait_hint: Duration::from_secs(0),
+                process_id: None,
+            },
+        )?;
 
         info!("Hestia Engine running");
 
@@ -110,34 +166,40 @@ mod win_service {
                     if !paused {
                         paused = true;
                         info!("Paused");
-                        status_handle.set_service_status(ServiceStatus {
-                            service_type: SERVICE_TYPE,
-                            current_state: ServiceState::Paused,
-                            controls_accepted: ServiceControlAccept::STOP
-                                | ServiceControlAccept::SHUTDOWN
-                                | ServiceControlAccept::PAUSE_CONTINUE,
-                            exit_code: ServiceExitCode::Win32(0),
-                            checkpoint: 0,
-                            wait_hint: Duration::from_secs(0),
-                            process_id: None,
-                        })?;
+                        set_status(
+                            &status_handle,
+                            ServiceStatus {
+                                service_type: SERVICE_TYPE,
+                                current_state: ServiceState::Paused,
+                                controls_accepted: ServiceControlAccept::STOP
+                                    | ServiceControlAccept::SHUTDOWN
+                                    | ServiceControlAccept::PAUSE_CONTINUE,
+                                exit_code: ServiceExitCode::Win32(0),
+                                checkpoint: 0,
+                                wait_hint: Duration::from_secs(0),
+                                process_id: None,
+                            },
+                        )?;
                     }
                 }
                 Ok(ServiceControl::Continue) => {
                     if paused {
                         paused = false;
                         info!("Continued");
-                        status_handle.set_service_status(ServiceStatus {
-                            service_type: SERVICE_TYPE,
-                            current_state: ServiceState::Running,
-                            controls_accepted: ServiceControlAccept::STOP
-                                | ServiceControlAccept::SHUTDOWN
-                                | ServiceControlAccept::PAUSE_CONTINUE,
-                            exit_code: ServiceExitCode::Win32(0),
-                            checkpoint: 0,
-                            wait_hint: Duration::from_secs(0),
-                            process_id: None,
-                        })?;
+                        set_status(
+                            &status_handle,
+                            ServiceStatus {
+                                service_type: SERVICE_TYPE,
+                                current_state: ServiceState::Running,
+                                controls_accepted: ServiceControlAccept::STOP
+                                    | ServiceControlAccept::SHUTDOWN
+                                    | ServiceControlAccept::PAUSE_CONTINUE,
+                                exit_code: ServiceExitCode::Win32(0),
+                                checkpoint: 0,
+                                wait_hint: Duration::from_secs(0),
+                                process_id: None,
+                            },
+                        )?;
                     }
                 }
                 Ok(_) => {}
@@ -155,29 +217,35 @@ mod win_service {
         }
 
         // Signal stop pending during shutdown/cleanup
-        status_handle.set_service_status(ServiceStatus {
-            service_type: SERVICE_TYPE,
-            current_state: ServiceState::StopPending,
-            controls_accepted: ServiceControlAccept::empty(),
-            exit_code: ServiceExitCode::Win32(0),
-            checkpoint: 1,
-            wait_hint: Duration::from_secs(10),
-            process_id: None,
-        })?;
+        set_status(
+            &status_handle,
+            ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: ServiceState::StopPending,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::Win32(0),
+                checkpoint: 1,
+                wait_hint: Duration::from_secs(10),
+                process_id: None,
+            },
+        )?;
 
         // TODO: Cleanup subsystems here
         info!("Hestia Engine stopped");
 
         // Final state: Stopped
-        status_handle.set_service_status(ServiceStatus {
-            service_type: SERVICE_TYPE,
-            current_state: ServiceState::Stopped,
-            controls_accepted: ServiceControlAccept::empty(),
-            exit_code: ServiceExitCode::Win32(0),
-            checkpoint: 0,
-            wait_hint: Duration::from_secs(0),
-            process_id: None,
-        })?;
+        set_status(
+            &status_handle,
+            ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: ServiceState::Stopped,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::Win32(0),
+                checkpoint: 0,
+                wait_hint: Duration::from_secs(0),
+                process_id: None,
+            },
+        )?;
 
         Ok(())
     }
@@ -185,7 +253,10 @@ mod win_service {
 
 #[cfg(windows)]
 fn main() {
-    win_service::main()
+    let args = win_service::Cli::parse();
+    if let Err(error) = win_service::main(args) {
+        eprintln!("{error:?}");
+    }
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
## Summary
- add a Clap-based CLI with a `--foreground` flag for the service host
- replace the log/env_logger setup with tracing subscribers and an ETW layer by default
- keep the Windows service loop functional while allowing console logging when running in foreground mode

## Testing
- cargo check -p hestia-engine


------
https://chatgpt.com/codex/tasks/task_e_68d42d846584832ab3a98fd7b27fd799